### PR TITLE
Allow custom timeout for generating mobile app icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ brew install imagemagick
 
 The default CLI for the `mini_magick` gem is set to auto pick. It will first try to use `GraphicsMagick` (if you have it installed) otherwise it will use `ImageMagick`. If you want to be explicit about which CLI you use, set the `minimagick_cli` option to `graphicsmagick` or `imagemagick`. Not specifying this option will set `MiniMagick` to use auto which will choose what's available.
 
+You can also set `minimagick_timeout` option to a desired value in seconds. Not specifying this option will set timeout to 5 seconds.
+
 ## About appicon
 
 Generate required icon sizes and iconset from a master application icon.

--- a/lib/fastlane/plugin/appicon/actions/android_appicon_action.rb
+++ b/lib/fastlane/plugin/appicon/actions/android_appicon_action.rb
@@ -43,7 +43,7 @@ module Fastlane
 
       def self.run(params)
 
-        Helper::AppiconHelper.set_cli(params[:minimagick_cli])
+        Helper::AppiconHelper.set_cli(params[:minimagick_cli], params[:minimagick_timeout])
 
         fname = params[:appicon_image_file]
         custom_sizes = params[:appicon_custom_sizes]
@@ -181,7 +181,12 @@ module Fastlane
                               verify_block: proc do |value|
                                         av = %w(graphicsmagick imagemagick)
                                         UI.user_error!("Unsupported minimagick cli '#{value}', must be: #{av}") unless av.include?(value)
-                                      end)
+                                      end),
+          FastlaneCore::ConfigItem.new(key: :minimagick_timeout,
+                                  env_name: "APPICON_MINIMAGICK_TIMEOUT",
+                               description: "Set MiniMagick CLI timeout (5 seconds by default)",
+                                  optional: true,
+                                      type: Integer)
         ]
       end
 

--- a/lib/fastlane/plugin/appicon/actions/appicon_action.rb
+++ b/lib/fastlane/plugin/appicon/actions/appicon_action.rb
@@ -69,7 +69,7 @@ module Fastlane
         fname = params[:appicon_image_file]
         basename = File.basename(fname, File.extname(fname))
 
-        Helper::AppiconHelper.set_cli(params[:minimagick_cli])
+        Helper::AppiconHelper.set_cli(params[:minimagick_cli], params[:minimagick_timeout])
 
         is_messages_extension = params[:messages_extension]
         basepath = Pathname.new(File.join(params[:appicon_path], is_messages_extension ? params[:appicon_messages_name] : params[:appicon_name]))
@@ -216,7 +216,12 @@ module Fastlane
                               verify_block: proc do |value|
                                         av = %w(graphicsmagick imagemagick)
                                         UI.user_error!("Unsupported minimagick cli '#{value}', must be: #{av}") unless av.include?(value)
-                                      end)
+                                      end),
+          FastlaneCore::ConfigItem.new(key: :minimagick_timeout,
+                                  env_name: "APPICON_MINIMAGICK_TIMEOUT",
+                               description: "Set MiniMagick CLI timeout (5 seconds by default)",
+                                  optional: true,
+                                      type: Integer)
         ]
       end
 

--- a/lib/fastlane/plugin/appicon/helper/appicon_helper.rb
+++ b/lib/fastlane/plugin/appicon/helper/appicon_helper.rb
@@ -9,7 +9,7 @@ module Fastlane
         UI.user_error!("Input image should be square") if image.width / image.height != width / height
       end
 
-      def self.set_cli(minimagick_cli)
+      def self.set_cli(minimagick_cli, timeout)
         MiniMagick.configure do |config|
           case minimagick_cli
           when "graphicsmagick"
@@ -19,7 +19,7 @@ module Fastlane
           else
             config.cli = MiniMagick.cli()
           end
-          config.timeout = 5
+          config.timeout = timeout || 5
         end
       end
 


### PR DESCRIPTION
Sometimes mobile CI has a slow moment, and won't finish creating the icons in the default timeout.

The idea is to add a customisable timeout, and propose this to upstream as well.

Won't merge this PR, it's just for review purposes.

**P.S. Note forks are public repos. Careful with what you comment.**